### PR TITLE
Upgraded Spectre.Console nuget packages

### DIFF
--- a/src/JKToolKit.Spectre.AutoCompletion.Tests/JKToolKit.Spectre.AutoCompletion.Tests.csproj
+++ b/src/JKToolKit.Spectre.AutoCompletion.Tests/JKToolKit.Spectre.AutoCompletion.Tests.csproj
@@ -25,9 +25,9 @@
 	<ItemGroup>
 		<PackageReference Include="Spectre.Verify.Extensions" Version="18.0.0" />
 		
-		<PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.1" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.49.2-preview.0.1" />
-		<PackageReference Include="Spectre.Console.Testing" Version="0.49.2-preview.0.1" />
+		<PackageReference Include="Spectre.Console" Version="0.50.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
+		<PackageReference Include="Spectre.Console.Testing" Version="0.50.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/JKToolKit.Spectre.AutoCompletion/Helpers/IsExternalInit.cs
+++ b/src/JKToolKit.Spectre.AutoCompletion/Helpers/IsExternalInit.cs
@@ -2,6 +2,6 @@
 #if !NET5_0_OR_GREATER
 namespace System.Runtime.CompilerServices
 {
-    internal static class IsExternalInit { }
+    internal sealed class IsExternalInit { }
 }
 #endif

--- a/src/JKToolKit.Spectre.AutoCompletion/Helpers/IsExternalInit.cs
+++ b/src/JKToolKit.Spectre.AutoCompletion/Helpers/IsExternalInit.cs
@@ -1,0 +1,7 @@
+// Polyfill for netstandard2.0 to support C# 9+ record types and init-only properties
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}
+#endif

--- a/src/JKToolKit.Spectre.AutoCompletion/JKToolKit.Spectre.AutoCompletion.csproj
+++ b/src/JKToolKit.Spectre.AutoCompletion/JKToolKit.Spectre.AutoCompletion.csproj
@@ -22,8 +22,9 @@
 		<InternalsAssemblyName Include="Spectre.Console" />
 		<InternalsAssemblyName Include="Spectre.Console.Cli" />
 
+		<InternalsAssemblyExcludeTypeName Include="System.Runtime.CompilerServices.IsExternalInit" />
 
-		<PackageReference Include="IgnoresAccessChecksToGenerator" Version="0.6.0" PrivateAssets="All" />
+		<PackageReference Include="IgnoresAccessChecksToGenerator" Version="0.8.0" PrivateAssets="all" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Update="Properties\Resources.Designer.cs">

--- a/src/JKToolKit.Spectre.AutoCompletion/JKToolKit.Spectre.AutoCompletion.csproj
+++ b/src/JKToolKit.Spectre.AutoCompletion/JKToolKit.Spectre.AutoCompletion.csproj
@@ -15,8 +15,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.1" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.49.2-preview.0.1" />
+		<PackageReference Include="Spectre.Console" Version="0.50.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<InternalsAssemblyName Include="Spectre.Console" />

--- a/src/samples/AutoCompletionExample/AutoCompletionExample.csproj
+++ b/src/samples/AutoCompletionExample/AutoCompletionExample.csproj
@@ -13,8 +13,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.1" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.49.2-preview.0.1" />
+		<PackageReference Include="Spectre.Console" Version="0.50.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
This pull request updates the `Spectre.Console` dependencies across the main project, test project, and sample project to version 0.50.0, and introduces compatibility improvements for .NET Standard 2.0 by adding a polyfill for `IsExternalInit`. It also updates the `IgnoresAccessChecksToGenerator` package and adjusts related project file configuration.

**Dependency updates:**

* Updated `Spectre.Console`, `Spectre.Console.Cli`, and `Spectre.Console.Testing` package references to version 0.50.0 in `JKToolKit.Spectre.AutoCompletion.csproj`, `JKToolKit.Spectre.AutoCompletion.Tests.csproj`, and `AutoCompletionExample.csproj`. [[1]](diffhunk://#diff-742576e972fea40fa5f14cc5ed28b248588d266f8f7a369a9322452bb8de53eeL18-R27) [[2]](diffhunk://#diff-eda4631d78dc30dcaa6497a58f343c194498e4cb0f88a7c9714597218116844aL28-R30) [[3]](diffhunk://#diff-eb74d0ee7c3b236fb4aa6f1775766e33345f43ce00260939e3936dcc5d3cf757L16-R17)
* Updated `IgnoresAccessChecksToGenerator` package to version 0.8.0 and set `PrivateAssets` to `all` in `JKToolKit.Spectre.AutoCompletion.csproj`.

**.NET Standard compatibility:**

* Added a polyfill for `System.Runtime.CompilerServices.IsExternalInit` in `Helpers/IsExternalInit.cs` to support C# 9 features (records and init-only properties) when targeting .NET Standard 2.0.
* Excluded the `IsExternalInit` type from internals access generation in the main project file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended C# 9+ language feature support (records, init-only properties) to .NET Standard 2.0 and older frameworks.

* **Chores**
  * Upgraded Spectre.Console dependencies from pre-release to stable version 0.50.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

resolves #7 